### PR TITLE
feat(nix): add flake.nix, shell.nix and default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 *.vsix
 target/
 bundled/
+result
+result-*

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+let
+  inherit (builtins) fromJSON readFile;
+  flake-compat = (fromJSON (readFile ./flake.lock)).nodes.flake-compat.locked;
+  url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.rev}.tar.gz";
+  tarball = fetchTarball {
+    url = flake-compat.url or url;
+    sha256 = flake-compat.narHash;
+  };
+in
+(import tarball { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,118 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1712903033,
+        "narHash": "sha256-KcvsEm0h1mIwBHFAzWFBjGihnbf2fxpAaXOdVbUfAI4=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "c739f83545e625227f4d0af7fe2a71e69931fa4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "ref": "master",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "main",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712915189,
+        "narHash": "sha256-fuz2iS599QQ4zocfSdOXpMPrg89WYJha1YRGOCElcEM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96881cfe769295bd50e355bd34d7e9b8946adcdc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712818880,
+        "narHash": "sha256-VDxsvgj/bNypHq48tQWtc3VRbWvzlFjzKf9ZZIVO10Y=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "657b33b0cb9bd49085202e91ad5b4676532c9140",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,82 @@
+{
+  description = "Source code spell checker for Visual Studio Code and LSP clients";
+
+  inputs = {
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-compat.url = "github:edolstra/flake-compat/master";
+    flake-utils.url = "github:numtide/flake-utils/main";
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+  };
+
+  outputs =
+    {
+      self,
+      fenix,
+      flake-utils,
+      nixpkgs,
+      ...
+    }:
+    let
+      inherit (builtins) fromTOML readFile;
+      inherit ((fromTOML (readFile ./crates/typos-lsp/Cargo.toml)).package) name version;
+    in
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        rustToolchain = fenix.packages.${system}.complete.withComponents [
+          "cargo"
+          "clippy"
+          "rust-analyzer"
+          "rust-src"
+          "rustc"
+          "rustfmt"
+        ];
+      in
+      {
+        apps =
+          let
+            default = flake-utils.lib.mkApp { drv = self.packages.${system}.default; };
+          in
+          {
+            inherit default;
+            ${name} = default;
+          };
+
+        devShells.default = pkgs.mkShell {
+          inherit name;
+
+          nativeBuildInputs = with pkgs; [
+            glib
+            pkg-config
+            rustToolchain
+          ];
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+
+        packages =
+          let
+            default =
+              (pkgs.makeRustPlatform {
+                cargo = rustToolchain;
+                rustc = rustToolchain;
+              }).buildRustPackage
+                {
+                  inherit version;
+                  pname = name;
+                  src = ./.;
+                  cargoLock.lockFile = ./Cargo.lock;
+                };
+          in
+          {
+            inherit default;
+            ${name} = default;
+          };
+      }
+    );
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+let
+  inherit (builtins) fromJSON readFile;
+  flake-compat = (fromJSON (readFile ./flake.lock)).nodes.flake-compat.locked;
+  url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.rev}.tar.gz";
+  tarball = fetchTarball {
+    url = flake-compat.url or url;
+    sha256 = flake-compat.narHash;
+  };
+in
+(import tarball { src = ./.; }).shellNix


### PR DESCRIPTION
With this PR, development with Nix/NixOS and integrating into the github:NixOS/nixpkgs is easy and would allow building a typos-lsp binary executable for VS Code/Codium Extension in NixOS.