### PR TITLE
refactor(tests): fix additional clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       env:
         RUST_LOG: debug,globset=warn
     - run: cargo fmt --all -- --check
-    - run: cargo clippy
+    - run: cargo clippy --all-targets
     - run: cargo build
     - run: npm ci
     - run: npm run lint

--- a/crates/typos-lsp/tests/integration_test.rs
+++ b/crates/typos-lsp/tests/integration_test.rs
@@ -179,19 +179,19 @@ async fn test_config_file() {
 
     // check "fo" is corrected to "of" because of default.extend-words
     similar_asserts::assert_eq!(
-        server.request(&did_open_diag_txt).await,
+        server.request(did_open_diag_txt).await,
         publish_diagnostics_with(&[diag("`fo` should be `of`", 0, 0, 2)], Some(&diag_txt))
     );
 
     // check changelog is excluded because of files.extend-exclude
     similar_asserts::assert_eq!(
-        server.request(&did_open_changelog_md).await,
+        server.request(did_open_changelog_md).await,
         publish_diagnostics_with(&[], Some(&changelog_md)),
     );
 
     // check skip_line is excluded because of default.extend-ignore-re
     similar_asserts::assert_eq!(
-        server.request(&did_open_skip_me).await,
+        server.request(did_open_skip_me).await,
         publish_diagnostics_with(&[], Some(&skip_me)),
     );
 }
@@ -220,7 +220,7 @@ async fn test_custom_config_file() {
     // check "fo" is corrected to "go" because of default.extend-words
     // in custom_typos.toml which overrides typos.toml
     similar_asserts::assert_eq!(
-        server.request(&did_open_diag_txt).await,
+        server.request(did_open_diag_txt).await,
         publish_diagnostics_with(&[diag("`fo` should be `go`", 0, 0, 2)], Some(&diag_txt))
     );
 }
@@ -247,7 +247,7 @@ async fn test_custom_config_no_workspace_folder() {
     // check "fo" is corrected to "go" because of default.extend-words
     // in custom_typos.toml which overrides typos.toml
     similar_asserts::assert_eq!(
-        server.request(&did_open_diag_txt).await,
+        server.request(did_open_diag_txt).await,
         publish_diagnostics_with(&[diag("`fo` should be `go`", 0, 0, 2)], Some(&diag_txt))
     );
 }
@@ -263,7 +263,7 @@ async fn test_non_file_uri() {
     let _ = server.request(&initialize_with(None, None)).await;
 
     similar_asserts::assert_eq!(
-        server.request(&did_open_diag_txt).await,
+        server.request(did_open_diag_txt).await,
         publish_diagnostics_with(
             &[diag("`apropriate` should be `appropriate`", 0, 0, 10)],
             Some(&term)
@@ -282,7 +282,7 @@ async fn test_empty_file_uri() {
     let _ = server.request(&initialize_with(None, None)).await;
 
     similar_asserts::assert_eq!(
-        server.request(&did_open_diag_txt).await,
+        server.request(did_open_diag_txt).await,
         publish_diagnostics_with(
             &[diag("`apropriate` should be `appropriate`", 0, 0, 10)],
             Some(&term)
@@ -298,14 +298,14 @@ async fn test_position_with_unicode_text() {
     // ¿ and é are two-byte code points in utf-8
     let unicode_text = &did_open("¿Qué hace él?");
     similar_asserts::assert_eq!(
-        server.request(&unicode_text).await,
+        server.request(unicode_text).await,
         publish_diagnostics(&[diag("`hace` should be `have`", 0, 5, 9)])
     );
 
     // ẽ has two code points U+0065 U+0303 (latin small letter e, combining tilde)
     let unicode_text = &did_open("ẽ hace");
     similar_asserts::assert_eq!(
-        server.request(&unicode_text).await,
+        server.request(unicode_text).await,
         publish_diagnostics(&[diag("`hace` should be `have`", 0, 3, 7)])
     );
 }
@@ -320,7 +320,7 @@ async fn test_ignore_typos_in_config_files() {
     let _ = server.request(&initialize_with(None, None)).await;
 
     similar_asserts::assert_eq!(
-        server.request(&did_open).await,
+        server.request(did_open).await,
         publish_diagnostics_with(&[], Some(&term))
     );
 }

--- a/crates/typos-lsp/tests/integration_test.rs
+++ b/crates/typos-lsp/tests/integration_test.rs
@@ -168,9 +168,9 @@ async fn test_config_file() {
     let changelog_md = workspace_folder_uri.join("tests/CHANGELOG.md").unwrap();
     let skip_me = workspace_folder_uri.join("tests/skip_me.txt").unwrap();
 
-    let did_open_diag_txt = &did_open_with("fo typos", Some(&diag_txt));
-    let did_open_changelog_md = &did_open_with("fo typos", Some(&changelog_md));
-    let did_open_skip_me = &did_open_with("fo typos # skip_me", Some(&skip_me));
+    let did_open_diag_txt = did_open_with("fo typos", Some(&diag_txt));
+    let did_open_changelog_md = did_open_with("fo typos", Some(&changelog_md));
+    let did_open_skip_me = did_open_with("fo typos # skip_me", Some(&skip_me));
 
     let mut server = TestServer::new();
     let _ = server
@@ -179,19 +179,19 @@ async fn test_config_file() {
 
     // check "fo" is corrected to "of" because of default.extend-words
     similar_asserts::assert_eq!(
-        server.request(did_open_diag_txt).await,
+        server.request(&did_open_diag_txt).await,
         publish_diagnostics_with(&[diag("`fo` should be `of`", 0, 0, 2)], Some(&diag_txt))
     );
 
     // check changelog is excluded because of files.extend-exclude
     similar_asserts::assert_eq!(
-        server.request(did_open_changelog_md).await,
+        server.request(&did_open_changelog_md).await,
         publish_diagnostics_with(&[], Some(&changelog_md)),
     );
 
     // check skip_line is excluded because of default.extend-ignore-re
     similar_asserts::assert_eq!(
-        server.request(did_open_skip_me).await,
+        server.request(&did_open_skip_me).await,
         publish_diagnostics_with(&[], Some(&skip_me)),
     );
 }
@@ -207,7 +207,7 @@ async fn test_custom_config_file() {
 
     let diag_txt = workspace_folder_uri.join("tests/diagnostics.txt").unwrap();
 
-    let did_open_diag_txt = &did_open_with("fo typos", Some(&diag_txt));
+    let did_open_diag_txt = did_open_with("fo typos", Some(&diag_txt));
 
     let mut server = TestServer::new();
     let _ = server
@@ -220,7 +220,7 @@ async fn test_custom_config_file() {
     // check "fo" is corrected to "go" because of default.extend-words
     // in custom_typos.toml which overrides typos.toml
     similar_asserts::assert_eq!(
-        server.request(did_open_diag_txt).await,
+        server.request(&did_open_diag_txt).await,
         publish_diagnostics_with(&[diag("`fo` should be `go`", 0, 0, 2)], Some(&diag_txt))
     );
 }
@@ -237,7 +237,7 @@ async fn test_custom_config_no_workspace_folder() {
 
     let diag_txt = workspace_folder_uri.join("tests/diagnostics.txt").unwrap();
 
-    let did_open_diag_txt = &did_open_with("fo typos", Some(&diag_txt));
+    let did_open_diag_txt = did_open_with("fo typos", Some(&diag_txt));
 
     let mut server = TestServer::new();
     let _ = server
@@ -247,7 +247,7 @@ async fn test_custom_config_no_workspace_folder() {
     // check "fo" is corrected to "go" because of default.extend-words
     // in custom_typos.toml which overrides typos.toml
     similar_asserts::assert_eq!(
-        server.request(did_open_diag_txt).await,
+        server.request(&did_open_diag_txt).await,
         publish_diagnostics_with(&[diag("`fo` should be `go`", 0, 0, 2)], Some(&diag_txt))
     );
 }
@@ -257,13 +257,13 @@ async fn test_non_file_uri() {
     // a Neovim toggleterm uri
     let term = Url::from_str("term://~/code/typos-lsp//59317:/bin/zsh;#toggleterm#1").unwrap();
 
-    let did_open_diag_txt = &did_open_with("apropriate", Some(&term));
+    let did_open_diag_txt = did_open_with("apropriate", Some(&term));
 
     let mut server = TestServer::new();
     let _ = server.request(&initialize_with(None, None)).await;
 
     similar_asserts::assert_eq!(
-        server.request(did_open_diag_txt).await,
+        server.request(&did_open_diag_txt).await,
         publish_diagnostics_with(
             &[diag("`apropriate` should be `appropriate`", 0, 0, 10)],
             Some(&term)
@@ -276,13 +276,13 @@ async fn test_empty_file_uri() {
     // eg: when using nvim telescope
     let term = Url::from_str("file:///").unwrap();
 
-    let did_open_diag_txt = &did_open_with("apropriate", Some(&term));
+    let did_open_diag_txt = did_open_with("apropriate", Some(&term));
 
     let mut server = TestServer::new();
     let _ = server.request(&initialize_with(None, None)).await;
 
     similar_asserts::assert_eq!(
-        server.request(did_open_diag_txt).await,
+        server.request(&did_open_diag_txt).await,
         publish_diagnostics_with(
             &[diag("`apropriate` should be `appropriate`", 0, 0, 10)],
             Some(&term)
@@ -296,16 +296,16 @@ async fn test_position_with_unicode_text() {
     let _ = server.request(&initialize()).await;
 
     // ¿ and é are two-byte code points in utf-8
-    let unicode_text = &did_open("¿Qué hace él?");
+    let unicode_text = did_open("¿Qué hace él?");
     similar_asserts::assert_eq!(
-        server.request(unicode_text).await,
+        server.request(&unicode_text).await,
         publish_diagnostics(&[diag("`hace` should be `have`", 0, 5, 9)])
     );
 
     // ẽ has two code points U+0065 U+0303 (latin small letter e, combining tilde)
-    let unicode_text = &did_open("ẽ hace");
+    let unicode_text = did_open("ẽ hace");
     similar_asserts::assert_eq!(
-        server.request(unicode_text).await,
+        server.request(&unicode_text).await,
         publish_diagnostics(&[diag("`hace` should be `have`", 0, 3, 7)])
     );
 }
@@ -314,13 +314,13 @@ async fn test_position_with_unicode_text() {
 async fn test_ignore_typos_in_config_files() {
     let term = Url::from_str("file:///C%3A/.typos.toml").unwrap();
 
-    let did_open = &did_open_with("apropriate", Some(&term));
+    let did_open = did_open_with("apropriate", Some(&term));
 
     let mut server = TestServer::new();
     let _ = server.request(&initialize_with(None, None)).await;
 
     similar_asserts::assert_eq!(
-        server.request(did_open).await,
+        server.request(&did_open).await,
         publish_diagnostics_with(&[], Some(&term))
     );
 }


### PR DESCRIPTION
# refactor: fix clippy warnings

This fixes warnings that were reported using
[bacon](https://github.com/Canop/bacon/tree/main)'s `clippy-all` job.

All of the warnings were for
<https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow>

It seems to use these command line flags:

```sh
# NOTE: bacon seems to run the longer command below, but this shorter command
# will also reproduce the warnings
cargo clippy --all-targets

# this is the longer command that bacon seems to run
cargo clippy --all-targets \
	--color always \
	-- \
	-A clippy::bool_to_int_with_if \
	-A clippy::collapsible_else_if \
	-A clippy::collapsible_if \
	-A clippy::derive_partial_eq_without_eq \
	-A clippy::len_without_is_empty \
	-A clippy::get_first \
	-A clippy::while_let_on_iterator
```

I ran into this by accident and figured it might be a good idea to fix them. I researched this a bit and think in practice they will have little to no performance impact - this seems to be motivated by simplicity and readability.

Here is the list of warnings that are generated by that command:

<details><summary>Details</summary>
<p>

Here is the list of warnings that are generated by that command:

```sh
 1  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:182:24
     |
 182 |         server.request(&did_open_diag_txt).await,
     |                        ^^^^^^^^^^^^^^^^^^ help: change this to: `did_open_diag_txt`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
     = note: `#[warn(clippy::needless_borrow)]` on by default

 2  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:188:24
     |
 188 |         server.request(&did_open_changelog_md).await,
     |                        ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `did_open_changelog_md`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

 3  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:194:24
     |
 194 |         server.request(&did_open_skip_me).await,
     |                        ^^^^^^^^^^^^^^^^^ help: change this to: `did_open_skip_me`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

 4  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:223:24
     |
 223 |         server.request(&did_open_diag_txt).await,
     |                        ^^^^^^^^^^^^^^^^^^ help: change this to: `did_open_diag_txt`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

 5  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:250:24
     |
 250 |         server.request(&did_open_diag_txt).await,
     |                        ^^^^^^^^^^^^^^^^^^ help: change this to: `did_open_diag_txt`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

 6  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:266:24
     |
 266 |         server.request(&did_open_diag_txt).await,
     |                        ^^^^^^^^^^^^^^^^^^ help: change this to: `did_open_diag_txt`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

 7  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:285:24
     |
 285 |         server.request(&did_open_diag_txt).await,
     |                        ^^^^^^^^^^^^^^^^^^ help: change this to: `did_open_diag_txt`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

 8  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:301:24
     |
 301 |         server.request(&unicode_text).await,
     |                        ^^^^^^^^^^^^^ help: change this to: `unicode_text`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

 9  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:308:24
     |
 308 |         server.request(&unicode_text).await,
     |                        ^^^^^^^^^^^^^ help: change this to: `unicode_text`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

10  warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> crates/typos-lsp/tests/integration_test.rs:323:24
     |
 323 |         server.request(&did_open).await,
     |                        ^^^^^^^^^ help: change this to: `did_open`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```

</p>
</details>

# ci: run clippy for all targets

I also added the extra `--all-targets` flag to the `clippy` job in the CI pipeline.