### PR TITLE
ci(release): add `aarch64-unknown-linux-musl`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,10 @@
 linker = "aarch64-linux-gnu-gcc"
 ar = "aarch64-linux-gnu-ar"
 
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"
+ar = "aarch64-linux-musl-ar"
+
 [target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 ar = "arm-linux-gnueabihf-ar"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,8 +5,8 @@ linker = "aarch64-linux-gnu-gcc"
 ar = "aarch64-linux-gnu-ar"
 
 [target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-musl-gcc"
-ar = "aarch64-linux-musl-ar"
+linker = "aarch64-linux-gnu-gcc"
+ar = "aarch64-linux-gnu-ar"
 
 [target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64
           - os: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            code-target: linux-arm64
           - os: ubuntu-20.04
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
@@ -65,6 +68,11 @@ jobs:
       - name: Install GCC armhf (linux)
         if: matrix.target == 'arm-unknown-linux-gnueabihf'
         run: sudo apt-get update && sudo apt-get install gcc-arm-linux-gnueabihf
+      - name: Install cross-compilation tools
+        with:
+          target: ${{ matrix.target }}
+        if: startsWith(matrix.os, 'ubuntu') && contains(matrix.target, '-musl')
+        uses: taiki-e/setup-cross-toolchain-action@v1
       - run: cargo build --target ${{ matrix.target }} --release
       - run: npm ci
       - name: vsce package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,8 @@ jobs:
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Install GCC arm64 (linux)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        if: startsWith(matrix.target, 'aarch64-unknown-linux')
         run: sudo apt-get update && sudo apt-get install gcc-aarch64-linux-gnu
-      - name: Install musl GCC (linux)
-        if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: sudo apt-get update && sudo apt-get install musl-gcc
       - name: Install GCC armhf (linux)
         if: matrix.target == 'arm-unknown-linux-gnueabihf'
         run: sudo apt-get update && sudo apt-get install gcc-arm-linux-gnueabihf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64
           - os: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64
           - os: ubuntu-20.04
@@ -68,11 +68,6 @@ jobs:
       - name: Install GCC armhf (linux)
         if: matrix.target == 'arm-unknown-linux-gnueabihf'
         run: sudo apt-get update && sudo apt-get install gcc-arm-linux-gnueabihf
-      - name: Install cross-compilation tools
-        with:
-          target: ${{ matrix.target }}
-        if: startsWith(matrix.os, 'ubuntu') && contains(matrix.target, '-musl')
-        uses: taiki-e/setup-cross-toolchain-action@v1
       - run: cargo build --target ${{ matrix.target }} --release
       - run: npm ci
       - name: vsce package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install GCC arm64 (linux)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: sudo apt-get update && sudo apt-get install gcc-aarch64-linux-gnu
+      - name: Install musl GCC (linux)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install musl-gcc
       - name: Install GCC armhf (linux)
         if: matrix.target == 'arm-unknown-linux-gnueabihf'
         run: sudo apt-get update && sudo apt-get install gcc-arm-linux-gnueabihf


### PR DESCRIPTION
Add a `aarch64-unknown-linux-musl` binary to the CI release builds.

Successful workflow run and build artifacts can be found [here](https://github.com/loicreynier/typos-lsp/actions/runs/12411262328).

I've tested successfully the `typos-lsp` binary however I am not able to test the `.vsix` package.

Close #145.