### PR TITLE
ci: fix release workflow by updating to the latest Ubuntu runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,19 @@ jobs:
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             code-target: linux-x64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
           - os: macos-latest


### PR DESCRIPTION
## What I did

This PR updates the workflow to use the latest available runner. The updated job completed successfully in [this run](https://github.com/kachick/typos-lsp/actions/runs/14923505228).

## Background

The ubuntu-20.04 runner was deprecated, as noted in [actions/runner-images#11101](https://github.com/actions/runner-images/issues/11101).

Referencing this deprecated runner caused GitHub Actions errors, blocking the release workflow for v0.1.37.

https://github.com/tekumara/typos-lsp/actions/runs/14831961185

![image](https://github.com/user-attachments/assets/31a1ff1e-542a-4388-94da-6f419f25d3a0)
![image](https://github.com/user-attachments/assets/7ace7e9a-8350-4a36-874f-64bc59402ade)

