### PR TITLE
docs: add Linux cargo install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ For [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) users:
 cargo binstall --git https://github.com/tekumara/typos-lsp typos-lsp
 ```
 
+For Linux users (via Cargo):
+
+```sh
+cargo install --git https://github.com/tekumara/typos-lsp typos-lsp
+```
+
 Or manually download `typos-lsp` from the [releases page](https://github.com/tekumara/typos-lsp/releases).
 
 ## Configuration


### PR DESCRIPTION
### What

Added installation instructions for Linux using cargo install to the README.

### Why

Currently the README only shows general instructions, but Linux users benefit from a direct example command. This makes setup faster and avoids confusion.